### PR TITLE
Add metadata to indexer

### DIFF
--- a/indexingLogic.js
+++ b/indexingLogic.js
@@ -454,6 +454,13 @@ async function getBlock(block: Block) {
             if (result.removed) linesRemoved += result.count;
           });
 
+          let forkSource = metadata?.fork_of ? metadata?.fork_of.split('@')[0]: null;
+          let forkBlockHeight = metadata?.fork_of ? metadata?.fork_of.split('@')[1]: null;
+          if (forkSource === `${componentAuthorId}/widget/${componentName}`) {
+            forkSource = null;
+            forkBlockHeight = null;
+          }
+
           const version = {
             block_height: blockHeight,
             block_timestamp_ms: blockTimestampMs,
@@ -463,6 +470,13 @@ async function getBlock(block: Block) {
             lines_added: linesAdded,
             lines_removed: linesRemoved,
             receipt_id: receiptId,
+            name: metadata?.name,
+            image_ipfs_cid: metadata?.image?.ipfs_cid,
+            description: metadata?.description,
+            fork_of_source: forkSource,
+            fork_of_block_height: forkBlockHeight,
+            tags: metadata?.tags ? Object.keys(metadata.tags).join(',') : null,
+            website: metadata?.website
           };
 
           console.log(
@@ -478,31 +492,19 @@ async function getBlock(block: Block) {
               "code",
               "lines_added",
               "lines_removed",
+              "name",
+              "image_ipfs_cid",
+              "description",
+              "fork_of_source",
+              "fork_of_block_height",
+              "tags",
+              "website"
             ]
           );
 
           console.log(
             `Successfully inserted component version record for: componentAuthorId=${componentAuthorId}, componentName=${componentName}`
           );
-
-          const versionId = versionsItems[0].id;
-          const metadataData = {
-            version_id: versionId,
-            block_height: blockHeight,
-            block_timestamp_ms: blockTimestampMs,
-            name: metadata?.name,
-            image_ipfs_cid: metadata?.image?.ipfs_cid,
-            description: metadata?.description,
-            fork_of: metadata?.fork_of,
-            tags: metadata?.tags ? Object.keys(metadata.tags).join(',') : null,
-            website: metadata?.website
-          }
-          await context.db.Metadata.insert(
-            metadataData
-          );
-
-          console.log(`Successfully inserted component metadata record for: componentAuthorId=${componentAuthorId}, componentName=${componentName}`);
-
         }
       } catch (err) {
         console.log(

--- a/indexingLogic.js
+++ b/indexingLogic.js
@@ -406,6 +406,8 @@ async function getBlock(block: Block) {
             continue;
           }
 
+          const metadata = componentData["metadata"];
+
           const code = componentData[""] || "";
           let previousCode = "";
           let linesAdded = 0;
@@ -467,7 +469,7 @@ async function getBlock(block: Block) {
             `Attempting to insert component version record for: componentAuthorId=${componentAuthorId}, componentName=${componentName}`
           );
 
-          await context.db.Versions.upsert(
+          const versionsItems = await context.db.Versions.upsert(
             version,
             ["receipt_id", "component_name", "component_author_id"],
             [
@@ -482,6 +484,24 @@ async function getBlock(block: Block) {
           console.log(
             `Successfully inserted component version record for: componentAuthorId=${componentAuthorId}, componentName=${componentName}`
           );
+
+          const versionId = versionsItems[0].id;
+          const metadataData = {
+            version_id: versionId,
+            block_height: blockHeight,
+            block_timestamp_ms: blockTimestampMs,
+            name: metadata?.name,
+            image_ipfs_cid: metadata?.image?.ipfs_cid,
+            description: metadata?.description,
+            fork_of: metadata?.fork_of,
+            tags: metadata?.tags ? Object.keys(metadata.tags).join(',') : null,
+          }
+          await context.db.Metadata.insert(
+            metadataData
+          );
+
+          console.log(`Successfully inserted component metadata record for: componentAuthorId=${componentAuthorId}, componentName=${componentName}`);
+
         }
       } catch (err) {
         console.log(

--- a/indexingLogic.js
+++ b/indexingLogic.js
@@ -495,6 +495,7 @@ async function getBlock(block: Block) {
             description: metadata?.description,
             fork_of: metadata?.fork_of,
             tags: metadata?.tags ? Object.keys(metadata.tags).join(',') : null,
+            website: metadata?.website
           }
           await context.db.Metadata.insert(
             metadataData

--- a/schema.sql
+++ b/schema.sql
@@ -31,6 +31,7 @@ CREATE TABLE
     "description" VARCHAR,
     "fork_of" VARCHAR,
     "tags" VARCHAR,
+    "website" VARCHAR,
     PRIMARY KEY ("id")
   );
 

--- a/schema.sql
+++ b/schema.sql
@@ -9,6 +9,13 @@ CREATE TABLE
     "lines_added" INT NOT NULL,
     "lines_removed" INT NOT NULL,
     "receipt_id" VARCHAR NOT NULL,
+    "name" VARCHAR,
+    "image_ipfs_cid" VARCHAR,
+    "description" VARCHAR,
+    "fork_of_source" VARCHAR,
+    "fork_of_block_height" BIGINT,
+    "tags" VARCHAR,
+    "website" VARCHAR,
     PRIMARY KEY ("id")
   );
 
@@ -20,22 +27,5 @@ CREATE INDEX
 CREATE INDEX
   idx_versions_block_height ON versions (block_height);
 
-CREATE TABLE
-  "metadata" (
-    "id" SERIAL,
-    "version_id" SERIAL NOT NULL,
-    "block_height" INT NOT NULL,
-    "block_timestamp_ms" BIGINT NOT NULL,
-    "name" VARCHAR,
-    "image_ipfs_cid" VARCHAR,
-    "description" VARCHAR,
-    "fork_of" VARCHAR,
-    "tags" VARCHAR,
-    "website" VARCHAR,
-    PRIMARY KEY ("id")
-  );
-
-ALTER TABLE
-  metadata
-ADD
-  CONSTRAINT metadata_version_id_fkey FOREIGN KEY (version_id) REFERENCES versions (id) ON DELETE CASCADE ON UPDATE NO ACTION;
+CREATE INDEX
+  idx_versions_fork_of ON versions (fork_of_source);

--- a/schema.sql
+++ b/schema.sql
@@ -1,14 +1,15 @@
 CREATE TABLE
   "versions" (
-    "id" SERIAL PRIMARY KEY,
-    "block_height" INT NOT NULL,
+    "id" SERIAL,
+    "block_height" BIGINT NOT NULL,
     "block_timestamp_ms" BIGINT NOT NULL,
     "code" VARCHAR NOT NULL,
     "component_author_id" VARCHAR NOT NULL,
     "component_name" VARCHAR NOT NULL,
     "lines_added" INT NOT NULL,
     "lines_removed" INT NOT NULL,
-    "receipt_id" VARCHAR NOT NULL
+    "receipt_id" VARCHAR NOT NULL,
+    PRIMARY KEY ("id")
   );
 
 CREATE UNIQUE INDEX idx_versions_unique_receipt_version ON versions (receipt_id, component_author_id, component_name);
@@ -18,3 +19,22 @@ CREATE INDEX
 
 CREATE INDEX
   idx_versions_block_height ON versions (block_height);
+
+CREATE TABLE
+  "metadata" (
+    "id" SERIAL,
+    "version_id" SERIAL NOT NULL,
+    "block_height" INT NOT NULL,
+    "block_timestamp_ms" BIGINT NOT NULL,
+    "name" VARCHAR,
+    "image_ipfs_cid" VARCHAR,
+    "description" VARCHAR,
+    "fork_of" VARCHAR,
+    "tags" VARCHAR,
+    PRIMARY KEY ("id")
+  );
+
+ALTER TABLE
+  metadata
+ADD
+  CONSTRAINT metadata_version_id_fkey FOREIGN KEY (version_id) REFERENCES versions (id) ON DELETE CASCADE ON UPDATE NO ACTION;


### PR DESCRIPTION
This PR adds metadata to the components indexer. The original code can be found here: https://near.org/dataplatform.near/widget/QueryApi.App?selectedIndexerPath=dataplatform.near/components.

The SQL schema has been changed due to the old version not properly generating.